### PR TITLE
Fix prediction with unknown categories

### DIFF
--- a/app.py
+++ b/app.py
@@ -424,7 +424,13 @@ with tabs[3]:
         X = df_modelo[["PosicionClasificacion", "Clima", "Escudería"]]
         y = df_modelo["Posición"]
         pre = ColumnTransformer(
-            [("cat", OneHotEncoder(drop="first"), ["Clima", "Escudería"])],
+            [
+                (
+                    "cat",
+                    OneHotEncoder(drop="first", handle_unknown="ignore"),
+                    ["Clima", "Escudería"],
+                )
+            ],
             remainder="passthrough",
         )
         modelo = Pipeline(


### PR DESCRIPTION
## Summary
- handle unseen categories during prediction by ignoring them in `OneHotEncoder`

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_686c6a16f2348333a6381d8817abc0ad