### PR TITLE
Fix OneHotEncoder param for sklearn 1.7

### DIFF
--- a/app.py
+++ b/app.py
@@ -429,7 +429,7 @@ with tabs[3]:
             [
                 (
                     "cat",
-                    OneHotEncoder(drop="first", handle_unknown="ignore", sparse=False),
+                    OneHotEncoder(drop="first", handle_unknown="ignore", sparse_output=False),
                     ["Clima", "Escudería"],
                 )
             ],


### PR DESCRIPTION
## Summary
- update the OneHotEncoder configuration for compatibility with modern scikit-learn

## Testing
- `streamlit run app.py`

------
https://chatgpt.com/codex/tasks/task_e_686c7ecf3804833384c2cb9b310ac63a