### PR TITLE
Fix OneHotEncoder arg

### DIFF
--- a/app.py
+++ b/app.py
@@ -429,7 +429,7 @@ with tabs[3]:
             [
                 (
                     "cat",
-                    OneHotEncoder(drop="first", handle_unknown="ignore", sparse_output=False),
+                    OneHotEncoder(drop="first", handle_unknown="ignore", sparse=False),
                     ["Clima", "Escudería"],
                 )
             ],


### PR DESCRIPTION
## Summary
- fix `OneHotEncoder` parameter for compatibility with older scikit-learn versions

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_686cf2eefb2483339f079157375becfd