### PR TITLE
Handle missing circuit coordinates

### DIFF
--- a/app.py
+++ b/app.py
@@ -124,16 +124,19 @@ def obtener_lat_lon_circuitos():
     url = "https://api.jolpi.ca/ergast/f1/circuits.json?limit=100"
     r = requests.get(url)
     datos = r.json()["MRData"]["CircuitTable"]["Circuits"]
-    return pd.DataFrame(
-        [
+    registros = []
+    for circuito in datos:
+        location = circuito.get("Location", {})
+        lat = pd.to_numeric(location.get("lat"), errors="coerce")
+        lon = pd.to_numeric(location.get("long"), errors="coerce")
+        registros.append(
             {
-                "Circuito": c["circuitName"],
-                "Lat": float(c["Location"]["lat"]),
-                "Lon": float(c["Location"]["long"]),
+                "Circuito": circuito.get("circuitName"),
+                "Lat": lat,
+                "Lon": lon,
             }
-            for c in datos
-        ]
-    )
+        )
+    return pd.DataFrame(registros).dropna(subset=["Lat", "Lon"])
 
 
 @st.cache_data(ttl=86400)


### PR DESCRIPTION
### Motivation

- Prevent a `TypeError` raised when converting non-numeric or missing circuit `Location` `lat`/`long` values to `float`.
- Ensure downstream merges and weather lookups receive only valid numeric coordinates to avoid runtime failures.
- Make `obtener_lat_lon_circuitos` more resilient to incomplete API data by handling absent `Location` fields.

### Description

- Replace the previous list-comprehension with an explicit loop that uses `circuito.get("Location", {})` to safely access location data.
- Coerce `lat` and `long` values to numeric using `pd.to_numeric(..., errors="coerce")` to turn invalid values into `NaN`.
- Build a `registros` list and return `pd.DataFrame(registros).dropna(subset=["Lat", "Lon"])` to exclude circuits without valid coordinates.
- Preserve the `@st.cache_data(ttl=86400)` decorator so results remain cached.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d73c3201c83339c9a44147977f836)