### PR TITLE
Ensure API results keep expected columns and handle missing circuit coordinates

### DIFF
--- a/app.py
+++ b/app.py
@@ -86,7 +86,19 @@ def cargar_datos_api(temporada):
         except Exception as e:
             st.error(f"Error al cargar resultados: {e}")
             break
-    return pd.DataFrame(registros)
+    columnas = [
+        "Temporada",
+        "Ronda",
+        "Fecha",
+        "Circuito",
+        "Pais",
+        "Piloto",
+        "Escudería",
+        "Posición",
+        "Puntos",
+        "Status",
+    ]
+    return pd.DataFrame(registros, columns=columnas)
 
 
 @st.cache_data(ttl=86400)
@@ -116,7 +128,8 @@ def cargar_posiciones_clasificacion(temporada):
                 )
         except Exception:
             continue
-    return pd.DataFrame(posiciones)
+    columnas = ["Temporada", "Ronda", "Piloto", "PosicionClasificacion"]
+    return pd.DataFrame(posiciones, columns=columnas)
 
 
 @st.cache_data(ttl=86400)
@@ -124,16 +137,19 @@ def obtener_lat_lon_circuitos():
     url = "https://api.jolpi.ca/ergast/f1/circuits.json?limit=100"
     r = requests.get(url)
     datos = r.json()["MRData"]["CircuitTable"]["Circuits"]
-    return pd.DataFrame(
-        [
+    registros = []
+    for circuito in datos:
+        location = circuito.get("Location", {})
+        lat = pd.to_numeric(location.get("lat"), errors="coerce")
+        lon = pd.to_numeric(location.get("long"), errors="coerce")
+        registros.append(
             {
-                "Circuito": c["circuitName"],
-                "Lat": float(c["Location"]["lat"]),
-                "Lon": float(c["Location"]["long"]),
+                "Circuito": circuito.get("circuitName"),
+                "Lat": lat,
+                "Lon": lon,
             }
-            for c in datos
-        ]
-    )
+        )
+    return pd.DataFrame(registros).dropna(subset=["Lat", "Lon"])
 
 
 @st.cache_data(ttl=86400)


### PR DESCRIPTION
### Motivation
- Prevent merge failures when API endpoints return no rows and the resulting DataFrames lack expected columns.  
- Avoid runtime errors when circuit `Location` fields are missing or non-numeric during coordinate conversion.  
- Make data-loading functions more resilient to incomplete or malformed API responses.  
- Preserve caching behavior for API-loading functions to retain performance and TTL guarantees.  

### Description
- Update `cargar_datos_api` to return `pd.DataFrame(registros, columns=columnas)` with an explicit `columnas` list so empty results still include expected columns.  
- Update `cargar_posiciones_clasificacion` to return `pd.DataFrame(posiciones, columns=columnas)` with explicit columns to avoid missing-column issues.  
- Rewrite `obtener_lat_lon_circuitos` to iterate circuits, use `circuito.get("Location", {})` and coerce coordinates via `pd.to_numeric(..., errors="coerce")`, then `dropna(subset=["Lat","Lon"])` to exclude invalid locations.  
- Keep all `@st.cache_data` decorators to maintain caching for the modified functions.  

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d73c3201c83339c9a44147977f836)